### PR TITLE
Replacing PHP_EOL to \n to ensure consistency across platforms 

### DIFF
--- a/src/Text.php
+++ b/src/Text.php
@@ -26,18 +26,19 @@ class Text
 	public static function textToArray($text, $delimiters = null): array
 	{
 		if (!$delimiters) {
-			$delimiters = [PHP_EOL, ';', ','];
+			$delimiters = ["\n", ';', ','];
 		}
 
-		$lines = str_replace($delimiters, $delimiters[0], $text);
+		// Normalize all line endings to \n
+		$text = str_replace(["\r\n", "\r"], "\n", $text);
 
-		$trimmedLines = array_map('trim', explode(PHP_EOL, $lines));
+		$lines = str_replace($delimiters, $delimiters[0], $text);
+		$trimmedLines = array_map('trim', explode("\n", $lines));
 
 		// remove empty values
 		$lines = array_filter($trimmedLines, function ($item) {
 			return $item !== '';
 		});
-
 		return $lines;
 	}
 

--- a/tests/Unit/TextTest.php
+++ b/tests/Unit/TextTest.php
@@ -14,11 +14,16 @@ class TextTest extends TestCase
 	{
 		$strings = [
 			"one\ntwo" => ["one", "two"],
+			"one\r\ntwo" => ["one", "two"],
+			"one\rtwo" => ["one", "two"],
+			"one\r\ntwo\rthree\nfour" => ["one", "two", "three", "four"],
+			" one , two ; three\n four " => ["one", "two", "three", "four"],
 			"one, two,   three
 four
 five" => ["one", "two", "three", "four", "five"],
 			"onetwo" => ["onetwo"],
 			"" => [],
+			" " => [],
 			"," => []
 		];
 


### PR DESCRIPTION
## Replacing PHP_EOL to \n to ensure consistency across platforms 

## Description

This PR updates the `textToArray` function to improve its handling of line endings and ensure consistent behavior across different operating systems. The changes include:
- Replacing the use of `PHP_EOL` with a consistent newline character `\n`.
- Adding a normalization step to convert all line endings (`\r\n` and `\r`) to `\n`.
- Adjusting the delimiter replacement and line splitting logic to use `\n` explicitly.

These changes address issues with inconsistent behavior when processing strings with mixed or non-standard line endings.

## Motivation and context

The previous implementation relied on `PHP_EOL`, which varies depending on the operating system. This caused the test cases to fail. This was because the value `PHP_EOL` is `\r\n` in Windows. 

This PR tries to improve it by normalizing line endings to `\n` and explicitly using it in the processing logic, the function now behaves consistently regardless of the environment.

This PR resolves the issue of failing test cases when processing text with different line-ending formats.

## How has this been tested?

Please describe in detail how you tested your changes.

The updated function has been tested using:
- Unit tests with strings containing various combinations of line endings (`\r\n`, `\r`, `\n`).
- Test cases with different delimiter combinations to ensure proper splitting and trimming.
- Edge cases, such as empty strings, lone delimiters, and strings with excessive whitespace.

## Screenshots (if appropriate)

![Failed test](https://github.com/user-attachments/assets/7d856330-1326-439b-a112-1e93a858fe87)
![image](https://github.com/user-attachments/assets/8b26fd5f-d568-4164-910c-6e864ff63bea)
![image](https://github.com/user-attachments/assets/b167b62c-b879-42bc-891a-c882f33adab2)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
